### PR TITLE
Replaced  warning with suggestion to redownload data files.

### DIFF
--- a/ea_space.m
+++ b/ea_space.m
@@ -43,5 +43,6 @@ switch cmd
 end
 
 if ~exist(path,'dir')
-    warning('This functionality seems not to be compatible with the space you are working in. Please consider using the default ICBM 2009b nonlinear asymmetric space for this procedure.');
+    warning('Not all atlas data is present. Please click on ''Install'' -> ''Redownload data files'' to download the required files');
+    %warning('This functionality seems not to be compatible with the space you are working in. Please consider using the default ICBM 2009b nonlinear asymmetric space for this procedure.');
 end


### PR DESCRIPTION
Replaced warning with appropriate suggestion to redownload data files. In my case downloading the data files avoids the warning 

> This functionality seems not to be compatible with the space you are working in. Please consider using the default ICBM 2009b nonlinear asymmetric space for this procedure

Instead it shows:

> Not all atlas data is present. Please click on 'Install' -> 'Redownload data files' to download the required files.