### PR TITLE
Also show the superfoldername in recent patients list

### DIFF
--- a/ea_updaterecentpatients.m
+++ b/ea_updaterecentpatients.m
@@ -5,7 +5,9 @@ end
 earoot=ea_getearoot;
 load([earoot,'common',filesep,'ea_recentpatients.mat']);
 for i=1:length(fullrpts)
-    [~,fullrpts{i}]=fileparts(fullrpts{i});
+    [path,foldername]=fileparts(fullrpts{i});
+    [~,superfoldername]=fileparts(path);
+    fullrpts{i} = [superfoldername filesep foldername];
 end
 try
     fullrpts=[{['Recent ',patsub,':']};fullrpts];


### PR DESCRIPTION
For example when you run leaddbs analysis in a subfolder "leaddbs" of each patientfolder your recent patient list will show "leaddbs" for each patient. With this change it will show "patientfolder/leaddbs".

Maybe this could also be made as a configurable option.