### PR TITLE
Fix normlock==0.5 branch crash in ea_autocoord

### DIFF
--- a/ea_autocoord.m
+++ b/ea_autocoord.m
@@ -247,7 +247,9 @@ if ~strcmp(options.patientname,'No Patient Selected') && ~isempty(options.patien
         elseif normlock == 1 % Both pre-op images coreg and norm were approved.
             doit = false;
         elseif normlock == 0.5 % Pre-op images coreg changed, rerun when using multispectral norm method.
-            [~, ~, ~, doit] = eval([options.normalize.method,'(''prompt'')']);
+            doit = questdlg('Coregistration changed. Redo normalization?', ...
+                'Normalization', 'Yes', 'No', 'Yes');
+            doit = strcmp(doit, 'Yes');
         else
             doit = true;
         end


### PR DESCRIPTION
Replace eval() call with questdlg to prompt user whether to redo  normalization when coregistration has changed but normalization  was previously approved. The eval() approach broke when  options.normalize.method contained the UI display name  (e.g. "SPM12 SHOOT (Ashburner 2011)").

Fixes #1316