### PR TITLE
FIX: prevent SPM job skipping on repeated coregistration runs

### DIFF
--- a/ea_spm_coreg.m
+++ b/ea_spm_coreg.m
@@ -46,6 +46,9 @@ end
 movingmat = spm_get_space(moving);
 fixedmat = spm_get_space(fixed);
 
+% Reset SPM's job manager state before every run to prevent silent job 
+% (SPM can skip a job if it recognises the same config from a previous call in the same session, producing no output and no error).
+spm_jobman('initcfg');
 if doreslice
     % backup moving image
     movingbackup = ea_niifileparts(moving);


### PR DESCRIPTION
This fixes an issue where repeated coregistration runs within the same MATLAB session could result in SPM jobs being silently skipped.

SPM may reuse a previous job configuration without re-executing it, producing no output and no error.

The fix resets the SPM job manager state (`spm_jobman('initcfg')`) before each run to ensure consistent execution.