### PR TITLE
Limit BIDS option enrichment to lead connectome and remove from ea_run()

### DIFF
--- a/ea_autocoord.m
+++ b/ea_autocoord.m
@@ -408,16 +408,6 @@ if ~strcmp(options.patientname,'No Patient Selected') && ~isempty(options.patien
             end
         end
 
-        % Restrict BIDS/path enrichment to the connectome pipeline.
-        directory = [options.root, options.patientname, filesep];
-        if contains(directory, ['derivatives', filesep, 'leaddbs'])
-            try
-                options = ea_getptopts(directory, options);
-            catch MEptopts
-                warning('Lead-Connectome option enrichment failed (%s). Continuing with existing options.', MEptopts.message);
-            end
-        end
-
         % If at least one *structural* Lead-Connectome option is enabled,
         % prepare DWI data (copy from rawdata, set prefs, export b0) before
         % entering the main Lead-Connectome routine. This mirrors the
@@ -438,7 +428,7 @@ if ~strcmp(options.patientname,'No Patient Selected') && ~isempty(options.patien
             if doStrucLC
                 % For BIDS-style datasets in derivatives/leaddbs, copy DWI
                 % from rawdata into preprocessing/dwi and set prefs.*.
-                if contains(directory, 'derivatives') || contains(directory, 'leaddbs')
+                if contains([options.root, options.patientname], {'derivatives', 'leaddbs'})
                     options = ea_prepare_dti_bids(options);
                 end
 

--- a/ea_autocoord.m
+++ b/ea_autocoord.m
@@ -408,6 +408,16 @@ if ~strcmp(options.patientname,'No Patient Selected') && ~isempty(options.patien
             end
         end
 
+        % Restrict BIDS/path enrichment to the connectome pipeline.
+        directory = [options.root, options.patientname, filesep];
+        if contains(directory, ['derivatives', filesep, 'leaddbs'])
+            try
+                options = ea_getptopts(directory, options);
+            catch MEptopts
+                warning('Lead-Connectome option enrichment failed (%s). Continuing with existing options.', MEptopts.message);
+            end
+        end
+
         % If at least one *structural* Lead-Connectome option is enabled,
         % prepare DWI data (copy from rawdata, set prefs, export b0) before
         % entering the main Lead-Connectome routine. This mirrors the
@@ -426,8 +436,6 @@ if ~strcmp(options.patientname,'No Patient Selected') && ~isempty(options.patien
             end
 
             if doStrucLC
-                directory = [options.root, options.patientname, filesep];
-
                 % For BIDS-style datasets in derivatives/leaddbs, copy DWI
                 % from rawdata into preprocessing/dwi and set prefs.*.
                 if contains(directory, 'derivatives') || contains(directory, 'leaddbs')

--- a/ea_run.m
+++ b/ea_run.m
@@ -101,11 +101,6 @@ else
                     end
                 end
 
-                % BIDS fix: Update prefs with correct BIDS paths if in derivatives folder
-                if contains(uipatdirs{i}, ['derivatives', filesep, 'leaddbs', filesep])
-                    options = ea_getptopts(uipatdirs{i}, options);
-                end
-
                 options.subjInd=i;
                 % run main function
                 if length(uipatdirs) > 1 % multi mode. Dont stop at errors.


### PR DESCRIPTION
- remove the generic "ea_getptopts()" call from "ea_run()"
- move BIDS/path enrichment into the connectome-only "options.dolc" path in "ea_autocoord()"
- avoids overriding DBS runtime options like electrode model and native/MNI scene selection during normal Lead-DBS runs
