### PR TITLE
Postprocessing cluster mode for OSS-DBS and pPAM fixes

### DIFF
--- a/ea_genvat_butenko.m
+++ b/ea_genvat_butenko.m
@@ -44,8 +44,10 @@ if islogical(settings) && ~settings
 end
 
 % some hardcoded parameters, can be added to the GUI later
-settings.reuse_warped_connectome = 0;  % set to 1 if the connectome was already processed for the given stim. settings
 prepFiles_cluster = 0; % set to 1 if you only want to prep files for cluster comp.
+postprocess_cluster = 0; % set to 1 if OSS-DBS was already run externally (e.g. on a cluster) and you only want Lead-DBS postprocessing. Mutually exclusive with prepFiles_cluster.
+settings.reuse_warped_connectome = postprocess_cluster;  % always reuse when postprocessing cluster results to preserve fiber-ID consistency with Axon_state_*.mat
+settings.postprocess_cluster = postprocess_cluster;  % gates destructive cleanup in ea_prepare_fibers and ea_save_ossdbs_settings (cluster output must not be wiped)
 true_VTA = 0; % set to 1 to compute classic VAT using axonal grids
 
 % set outputs
@@ -124,7 +126,7 @@ for source_index = first_active_source:4
         parameterFile = ea_save_ossdbs_settings(options, S, settings, outputPaths);
     end
 
-    if prepFiles_cluster == 1
+    if prepFiles_cluster == 1 && ~postprocess_cluster
         % now you can run OSS-DBS externally
         [varargout{1}, varargout{2}] = ea_exit_genvat_butenko();
         return
@@ -145,8 +147,11 @@ for source_index = first_active_source:4
         % hemisphere specific data is stored in this subfolder
         outputPaths.HemiSimFolder = [outputPaths.outputDir, filesep, 'OSS_sim_files_', sideCode];
 
-        if ~multiSourceMode(side+1)
-            % not relevant in this case, terminate after one iteration;
+        if ~multiSourceMode(side+1) || settings.postprocess_cluster
+            % not relevant in this case, terminate after one iteration.
+            % For postprocess_cluster, we collapse multisource to single-source
+            % semantics (cluster only ran source 1), so the BIDS filename should
+            % follow single-source convention (no _<source_index> suffix).
             source_use_index = 5;
         else
             source_use_index = source_index;
@@ -213,6 +218,12 @@ for source_index = first_active_source:4
         end
 
         %% OSS-DBS part (using the corresponding conda environment)
+        if postprocess_cluster
+            % OSS-DBS was already run externally; skip the simulation loop
+            % and go straight to Lead-DBS postprocessing.
+            i = 1;
+            parameterFile_json = [outputPaths.HemiSimFolder, filesep, 'oss-dbs_parameters.json'];
+        else
         for i = 1:settings.N_samples  % mutiple samples if probablistic PAM is used, otherwise 1
 
             if settings.calcAxonActivation
@@ -234,8 +245,8 @@ for source_index = first_active_source:4
 
                 % allocate computational axons on fibers
                 %system(['python ', ea_getearoot, 'ext_libs/OSS-DBS/Axon_Processing/axon_allocation.py ', outputPaths.outputDir,' ', num2str(side), ' ', parameterFile]);
-                
-                if settings.use_wsl 
+
+                if settings.use_wsl
                     [~,cmdout] = vta_runwslcommand(options.prefs.ext_oss_env,['prepareaxonmodel ',vta_windowspathstowsl(outputPaths.outputDir),' --hemi_side ',num2str(side),' --description_file ', vta_windowspathstowsl(parameterFile)])
                 else
                     if settings.use_binaries
@@ -247,7 +258,7 @@ for source_index = first_active_source:4
             end
 
             % prepare OSS-DBS input as oss-dbs_parameters.json
-            if settings.use_wsl 
+            if settings.use_wsl
                 [~,cmdout] = vta_runwslcommand(options.prefs.ext_oss_env,['leaddbs2ossdbs --hemi_side ', num2str(side), ' ', vta_windowspathstowsl(parameterFile), ...
                     ' --output_path ', vta_windowspathstowsl(outputPaths.HemiSimFolder)]);
             else
@@ -263,7 +274,7 @@ for source_index = first_active_source:4
             parameterFile_json = [outputPaths.HemiSimFolder, filesep, input_name, '.json'];
 
             % run OSS-DBS
-            if settings.use_wsl 
+            if settings.use_wsl
                 [~,cmdout] = vta_runwslcommand(options.prefs.ext_oss_env,['ossdbs ', vta_windowspathstowsl(parameterFile_json)])
             else
                 if settings.use_binaries
@@ -275,7 +286,7 @@ for source_index = first_active_source:4
             % detect error related to Bnd_Box
             if contains(cmdout, 'Bnd_Box is void')
                 disp ('Error "Bnd_Box is void" detected, increasing the dimensions ...');
-                if settings.use_wsl 
+                if settings.use_wsl
                     [~,cmdout] = vta_runwslcommand(options.prefs.ext_oss_env,cell2mat(['python3 ' vta_windowspathstowsl(ea_regexpdir(ea_getearoot, 'BndBoxDimensionsEdits.py')) ' ', vta_windowspathstowsl(parameterFile_json)]))
                     % run OSS-DBS
                     [~,cmdout] = vta_runwslcommand(options.prefs.ext_oss_env,['ossdbs ', vta_windowspathstowsl(parameterFile_json)])
@@ -311,7 +322,7 @@ for source_index = first_active_source:4
                 end
 
                 if settings.optimizer
-                    if settings.use_wsl 
+                    if settings.use_wsl
                         vta_runwslcommand(options.prefs.ext_oss_env,['python ', vta_windowspathstowsl(ea_getearoot,'ext_libs',filesep,'PathwayTune',filesep,'pam_optimizer.py'),' ', settings.PathwayTune_master_dict, ' ', vta_windowspathstowsl(outputPaths.outputDir), ' ', num2str(side), ' ', vta_windowspathstowsl(parameterFile_json), ' ', num2str(scaling)])
                     else
                         env.system('pip3 install pyswarms');
@@ -346,7 +357,7 @@ for source_index = first_active_source:4
                 ea_delete([outputPaths.HemiSimFolder, filesep, 'Results', filesep,'oss_time_result*'])
             end
 
-            if settings.prob_PAM && settings.stimSetMode    
+            if settings.prob_PAM && settings.stimSetMode
                 % we need to save the results since both modes use
                 % scaling_index
                 act_files = dir_without_dots([outputPaths.HemiSimFolder,filesep,'Results',filesep,'Pathway_status_*']);
@@ -354,12 +365,12 @@ for source_index = first_active_source:4
                 for act_file_inx = 1:length(act_files)
                     % Get the individual filename
                     fileName = act_files(act_file_inx).name;
-                    
+
                     % Skip directories (like '.' and '..')
                     if ~act_files(act_file_inx).isdir
                         sourceFile = fullfile(act_files(act_file_inx).folder, fileName);
                         destFile = fullfile([outputPaths.HemiSimFolder,filesep,'sample_',num2str(i)], fileName);
-                        
+
                         % Perform the copy
                         copyfile(sourceFile, destFile);
                         fprintf('Copied: %s\n', fileName);
@@ -373,17 +384,23 @@ for source_index = first_active_source:4
             end
 
         end
+        end % end of "if postprocess_cluster ... else ... end"
 
         %% Postprocessing in Lead-DBS
 
         % Check if OSS-DBS calculation is finished
-        while ~isfile([outputPaths.HemiSimFolder, filesep, 'success_', sideCode, '.txt']) ...
-                && ~isfile([outputPaths.HemiSimFolder, filesep, 'fail_', sideCode, '.txt'])
-            continue;
+        if ~postprocess_cluster
+            while ~isfile([outputPaths.HemiSimFolder, filesep, 'success_', sideCode, '.txt']) ...
+                    && ~isfile([outputPaths.HemiSimFolder, filesep, 'fail_', sideCode, '.txt'])
+                continue;
+            end
         end
 
-        if settings.prob_PAM && all(~multiSourceMode) && ~settings.stimSetMode
+        if settings.prob_PAM && (all(~multiSourceMode) || settings.postprocess_cluster) && ~settings.stimSetMode
             % convert binary PAM status over uncertain parameter to "probabilistic activations"
+            % NOTE: for postprocess_cluster, we force the single-source aggregator even when
+            % multisource is configured -- the cluster only ran source 1, so multisource OR-merging
+            % is meaningless (and the multisource pipeline destructively consumes Axon_state files).
             ea_get_probab_axon_state([outputPaths.HemiSimFolder,filesep,'Results'],1,settings,side);
         end
 
@@ -392,9 +409,13 @@ for source_index = first_active_source:4
             ea_delete([outputPaths.HemiSimFolder, filesep, 'Results', filesep, 'oss_freq_domain_tmp_PAM.hdf5']);
         end
 
-        if isfile([outputPaths.HemiSimFolder, filesep, 'success_', sideCode, '.txt'])
+        if isfile([outputPaths.HemiSimFolder, filesep, 'success_', sideCode, '.txt']) || postprocess_cluster
             runStatusMultiSource(source_index,side+1) = 1;
-            fprintf('\nOSS-DBS calculation succeeded!\n\n')
+            if postprocess_cluster
+                fprintf('\nRunning Lead-DBS postprocessing on existing OSS-DBS results...\n\n')
+            else
+                fprintf('\nOSS-DBS calculation succeeded!\n\n')
+            end
 
             if settings.prob_PAM && settings.stimSetMode
                 % TBA: Lead-DBS postprocessing for such case
@@ -412,7 +433,7 @@ for source_index = first_active_source:4
                 [stimparams(side+1).VAT.VAT,stimparams(side+1).volume,source_efields{side+1,source_use_index},source_vtas{side+1,source_use_index}] = ea_convert_ossdbs_VTAs(options,settings,side,multiSourceMode,source_use_index,outputPaths);
             end
 
-            if settings.prob_PAM && any(multiSourceMode) && ~settings.stimSetMode
+            if settings.prob_PAM && any(multiSourceMode) && ~settings.stimSetMode && ~settings.postprocess_cluster
                 % for multisource, we will convert in the external loop
                 % we just need to add the source index to the Axon States
                 axonStateFolder = ea_sourceIndex4AxonStates(outputPaths, side, source_use_index);
@@ -443,7 +464,8 @@ for source_index = first_active_source:4
     end
 
     % check only the first source for PAM
-    if all(~multiSourceMode)
+    % (also break for postprocess_cluster -- cluster only ran source 1)
+    if all(~multiSourceMode) || settings.postprocess_cluster
         runStatusMultiSource(2:end,:) = 1;
         break
     end
@@ -463,7 +485,8 @@ for side = 0:1
 end
 
 % special case for multisource probabilistic PAM
-if any(multiSourceMode) && settings.prob_PAM
+% (skipped when postprocessing cluster results -- handled via the single-source path above)
+if any(multiSourceMode) && settings.prob_PAM && ~settings.postprocess_cluster
     ea_get_prob_fiber_states_for_multisource(options,settings,outputPaths,axonStateFolder,resultfig)
 end
 

--- a/ext_libs/OSS-DBS/Axon_Processing/ea_get_probab_axon_state.m
+++ b/ext_libs/OSS-DBS/Axon_Processing/ea_get_probab_axon_state.m
@@ -69,6 +69,7 @@ end
 % we compute probabilities for the filtered fibers and will map to global
 % indices later in ea_genvat_butenko
 for pt_counter = 1:length(pathways)
+    skip_pathway = false;
     % iterate over scalings (fiber diameters)
     % important: number of compartments can differ based on the fiber
     % diameter / length!
@@ -89,8 +90,27 @@ for pt_counter = 1:length(pathways)
         else
             Axon_state_file = fullfile(results_folder, ['Axon_state_',pathways{pt_counter},'_',num2str(sample_i),'.mat']);
         end
- 
-        load(Axon_state_file, 'fibers','ea_fibformat','connectome_name');
+
+        try
+            load(Axon_state_file, 'fibers','ea_fibformat','connectome_name');
+        catch ME
+            % Corrupt / non-MAT cluster output for this pathway. Skip rather
+            % than crash -- downstream merge code treats a missing *_prob.mat
+            % as zero activation.
+            fprintf('Skipping pathway %s: failed to load sample %d (%s).\n     file: %s\n', ...
+                pathways{pt_counter}, sample_i, ME.message, Axon_state_file);
+            skip_pathway = true;
+            break;
+        end
+        if isempty(fibers)
+            % No axons survived for this pathway (e.g. all pre-filtered by
+            % Kuncel VTA). Skip the whole pathway -- downstream merge code
+            % treats a missing *_prob.mat as zero activation.
+            fprintf('Skipping pathway %s: empty fibers in sample %d (no *_prob.mat will be written).\n', ...
+                pathways{pt_counter}, sample_i);
+            skip_pathway = true;
+            break;
+        end
         n_comp = sum(bsxfun(@eq, fibers(:,4), fibers(:,4)'), 2)';
         % the number is the same since these are OSS-DBS axons
         idx = n_comp(1) * ones(length(unique(fibers(:,4))),1);
@@ -123,6 +143,10 @@ for pt_counter = 1:length(pathways)
             idx_comp_orig = find(fibers_prob(:,4)==fiber_i);
             fibers_prob(idx_comp_orig,5) = fibers_prob(idx_comp_orig,5) + fibers_state(fiber_i) / N_samples;
         end
+    end
+    if skip_pathway
+        % no axons survived for any sample -> nothing to write
+        continue;
     end
     ftr.fibers = fibers_prob;
     ftr.ea_fibformat = ea_fibformat;

--- a/ext_libs/OSS-DBS/Axon_Processing/ea_get_probab_axon_state.m
+++ b/ext_libs/OSS-DBS/Axon_Processing/ea_get_probab_axon_state.m
@@ -12,6 +12,19 @@ end
 
 % check which pathways were simulated and their percent activations
 rate_files = dir([results_folder,filesep,'Pathway_status*']);
+
+% Keep only numbered per-sample files; drop stale unnumbered files.
+if ~isempty(rate_files)
+    isNumbered = ~cellfun(@isempty, regexp({rate_files.name}, '_\d+\.json$', 'once'));
+    rate_files = rate_files(isNumbered);
+end
+if isempty(rate_files)
+    ea_cprintf('CmdWinWarnings', ...
+        '[prob-PAM] No probabilistic Pathway_status_*_<i>.json files in %s. Skipping aggregation.\n', ...
+        results_folder);
+    return
+end
+
 pathways = {};
 activations_over_pathways = {};
 pt_counter = 0;
@@ -32,10 +45,15 @@ for file_i = 1:length(rate_files)
     end
     rate_file = fullfile(rate_files(file_i).folder, ['Pathway_status_',pathway_name_orig,'_',num2str(scaling_counter),'.json']);
     scaling_counter = scaling_counter + 1;
+    if ~isfile(rate_file)
+        % Fallback: expected per-sample file missing; skip instead of crashing.
+        ea_cprintf('CmdWinWarnings', '[prob-PAM] Expected sample file not found, skipping: %s\n', rate_file);
+        continue;
+    end
     jsonText = fileread(rate_file);
     disp(rate_file)
-    % Convert JSON formatted text to MATLAB data types 
-    jsonDict = jsondecode(jsonText); 
+    % Convert JSON formatted text to MATLAB data types
+    jsonDict = jsondecode(jsonText);
     %pathway_name = strrep(pathway_name_orig,'_',' ');
     index = rate_files(file_i).name(end-5);
     if ~any(strcmp(pathways,pathway_name_orig))
@@ -60,7 +78,7 @@ if plot_rates
         ylim([0,100]);
         xlabel('Scaling')
         ylabel('Percent Activation')
-        hold on 
+        hold on
     end
     legend('Location','eastoutside')
 end

--- a/ext_libs/OSS-DBS/genvat_butenko/ea_get_probab_axon_state_for_multisource.m
+++ b/ext_libs/OSS-DBS/genvat_butenko/ea_get_probab_axon_state_for_multisource.m
@@ -11,6 +11,12 @@ end
 
 % check which pathways were simulated and their percent activations
 axon_state_files = dir([results_folder,filesep,'Axon_state_*']);
+if isempty(axon_state_files)
+    ea_cprintf('CmdWinWarnings', ...
+        '[multisource-prob] No Axon_state_* files in %s. Skipping probabilistic aggregation.\n', ...
+        results_folder);
+    return
+end
 pathways = {};
 activations_over_pathways = {};
 pt_counter = 0;
@@ -39,19 +45,42 @@ for file_i = 1:length(axon_state_files)
     end
 end
 
+if pt_counter == 0
+    ea_cprintf('CmdWinWarnings', ...
+        '[multisource-prob] %d files found but no pathway names recovered. Skipping.\n', ...
+        numel(axon_state_files));
+    return
+end
+
 N_scalings = length(activations_over_pathways{pt_counter});
 
 % now let's compute activation probabilty for each fiber
 % we compute probabilities for the filtered fibers and will map to global
 % indices later in ea_genvat_butenko
 for pt_counter = 1:length(pathways)
+    skip_pathway = false;
     % iterate over scalings (fiber diameters)
     % important: number of compartments can differ based on the fiber
     % diameter / length!
     for scaling_i = 1:N_scalings
 
         Axon_state_file = fullfile(results_folder, ['Axon_state_',pathways{pt_counter},'_',num2str(scaling_i),'.mat']);
+        if ~isfile(Axon_state_file)
+            fprintf('[multisource-prob] Missing sample file (skipping pathway %s): %s\n', ...
+                pathways{pt_counter}, Axon_state_file);
+            skip_pathway = true;
+            break;
+        end
         load(Axon_state_file, 'fibers','ea_fibformat','connectome_name');
+        if isempty(fibers)
+            % No axons survived for this pathway (e.g. all pre-filtered by
+            % Kuncel VTA). Skip the whole pathway -- downstream merge code
+            % treats a missing *_prob.mat as zero activation.
+            fprintf('[multisource-prob] Skipping pathway %s: empty fibers in sample %d.\n', ...
+                pathways{pt_counter}, scaling_i);
+            skip_pathway = true;
+            break;
+        end
 
         % intialize new axon state file with probabilistic activations
         % morphologz defined by the first scaling!
@@ -78,6 +107,10 @@ for pt_counter = 1:length(pathways)
             fibers_prob(idx_comp_orig,5) = fibers_prob(idx_comp_orig,5) + fibers_state(fiber_i) / N_scalings;
         end
         ea_delete(Axon_state_file);
+    end
+    if skip_pathway
+        % no axons survived for any sample -> nothing to write
+        continue;
     end
     ftr.fibers = fibers_prob;
     ftr.ea_fibformat = ea_fibformat;

--- a/ext_libs/OSS-DBS/genvat_butenko/ea_postprocess_multisource_axonstates.m
+++ b/ext_libs/OSS-DBS/genvat_butenko/ea_postprocess_multisource_axonstates.m
@@ -15,6 +15,11 @@ end
 
 % get all fiberActivations (make sure you don't have merged once before running it!)
 axonActivations = dir([axonStateFolder,filesep,'Axon_state_*']);
+if isempty(axonActivations)
+    ea_cprintf('CmdWinWarnings', ...
+        '[multisource-merge] Nothing to merge: %s has no Axon_state_* files.\n', axonStateFolder);
+    return
+end
 
 already_merged_index = [];
 for pam_idx = 1:size(axonActivations,1)

--- a/ext_libs/OSS-DBS/genvat_butenko/ea_prepare_fibers.m
+++ b/ext_libs/OSS-DBS/genvat_butenko/ea_prepare_fibers.m
@@ -64,16 +64,18 @@ if ~startsWith(settings.connectome, 'Multi-Tract: ') % Normal connectome
         % also create a folder for PAM results
         % clean up for the first source only
         if source_i == 1
-            if exist(settings.connectomeActivations,'dir')
+            % Skip destructive cleanup if we're only postprocessing cluster results.
+            postprocess_cluster = isfield(settings,'postprocess_cluster') && settings.postprocess_cluster;
+            if exist(settings.connectomeActivations,'dir') && ~postprocess_cluster
                 ea_delete(settings.connectomeActivations);
                 % remove all PAM folders
                 ea_delete([settings.connectomePath,filesep,'PAM*']);
             end
             ea_mkdir(settings.connectomeActivations);
-    
+
             if options.native
                 settings.connectomePathMNI = [outputPaths.templateOutputDir, filesep, settings.connectome];
-                if exist(settings.connectomePathMNI,'dir')
+                if exist(settings.connectomePathMNI,'dir') && ~postprocess_cluster
                     ea_delete(settings.connectomePathMNI);
                 end
                 ea_mkdir(settings.connectomePathMNI);
@@ -175,16 +177,18 @@ else % Multi-Tract connectome
         % also create a folder for PAM results
         % clean up for the first source only
         if source_i == 1
-            if exist(settings.connectomeActivations,'dir')
+            % Skip destructive cleanup if we're only postprocessing cluster results.
+            postprocess_cluster = isfield(settings,'postprocess_cluster') && settings.postprocess_cluster;
+            if exist(settings.connectomeActivations,'dir') && ~postprocess_cluster
                 ea_delete(settings.connectomeActivations);
                 % remove all PAM folders
                 ea_delete([settings.connectomePath,filesep,'PAM*']);
             end
             ea_mkdir(settings.connectomeActivations);
-    
+
             if options.native
                 settings.connectomePathMNI = [outputPaths.templateOutputDir, filesep, connName];
-                if exist(settings.connectomePathMNI,'dir')
+                if exist(settings.connectomePathMNI,'dir') && ~postprocess_cluster
                     ea_delete(settings.connectomePathMNI);
                 end
                 ea_mkdir(settings.connectomePathMNI);

--- a/ext_libs/OSS-DBS/genvat_butenko/ea_prepare_fibers.m
+++ b/ext_libs/OSS-DBS/genvat_butenko/ea_prepare_fibers.m
@@ -101,15 +101,20 @@ if ~startsWith(settings.connectome, 'Multi-Tract: ') % Normal connectome
             patient_specific = 0;
         end
     
-        % Filter fibers based on the minimal length
+        % Filter fibers based on the minimal length.
+        % In native space the length filter is deferred to AFTER the warp
+        % below, because the non-rigid warp into native space can shorten
+        % fibers below the threshold.
         inlay = 0.5;
-        fiberFiltered = ea_filterfiber_len(fiberFiltered, settings.axonLength+inlay);
-    
+        if ~options.native || patient_specific
+            fiberFiltered = ea_filterfiber_len(fiberFiltered, settings.axonLength+inlay);
+        end
+
         % Move original fiber id to the 5th column, the 4th column will be 1:N
         fibersFound = zeros(size(fiberFiltered));
         for i=1:length(fiberFiltered)
             if ~isempty(fiberFiltered{i}.fibers)
-    
+
                 % Convert connectome fibers from MNI space to anchor space
                 if options.native && patient_specific == 0
                     fprintf('Convert connectome into native space...\n\n');
@@ -118,13 +123,21 @@ if ~startsWith(settings.connectome, 'Multi-Tract: ') % Normal connectome
                         [ea_space, options.primarytemplate, '.nii'], ...
                         [options.subj.subjDir, filesep, 'forwardTransform'], ...
                         preopAnchor)';
+
+                    % Re-filter by length in native space (the warp may have
+                    % shortened fibers below the threshold)
+                    fiberFiltered(i) = ea_filterfiber_len(fiberFiltered{i}, settings.axonLength+inlay);
                 end
 
-                fibers = zeros(size(fiberFiltered{i}.fibers,1),5);
-                fibers(:,[1,2,3,5]) = fiberFiltered{i}.fibers;
-                fibers(:,4) = repelem(1:length(fiberFiltered{i}.idx), fiberFiltered{i}.idx)';
-                fiberFiltered{i}.fibers = fibers;
-                fibersFound(i) = 1;
+                % The native-space length filter above may have emptied this
+                % element, so re-check before rearranging columns.
+                if ~isempty(fiberFiltered{i}.fibers)
+                    fibers = zeros(size(fiberFiltered{i}.fibers,1),5);
+                    fibers(:,[1,2,3,5]) = fiberFiltered{i}.fibers;
+                    fibers(:,4) = repelem(1:length(fiberFiltered{i}.idx), fiberFiltered{i}.idx)';
+                    fiberFiltered{i}.fibers = fibers;
+                    fibersFound(i) = 1;
+                end
             end
         end
     
@@ -254,14 +267,19 @@ else % Multi-Tract connectome
                 patient_specific = 0;
             end
     
-            % Filter fibers based on the minimal length
+            % Filter fibers based on the minimal length.
+            % In native space the length filter is deferred to AFTER the warp
+            % below, because the non-rigid warp into native space can shorten
+            % fibers below the threshold.
             inlay = 0.5;
-            fiberFiltered = ea_filterfiber_len(fiberFiltered, settings.axonLength(t)+inlay);
-    
+            if ~options.native || patient_specific
+                fiberFiltered = ea_filterfiber_len(fiberFiltered, settings.axonLength(t)+inlay);
+            end
+
             % Move original fiber id to the 5th column, the 4th column will be 1:N
             for i=1:length(fiberFiltered)
                 if ~isempty(fiberFiltered{i}.fibers)
-    
+
                     % Convert connectome fibers from MNI space to anchor space
                     if options.native && patient_specific == 0
                         fprintf('Convert connectome into native space...\n\n');
@@ -270,20 +288,28 @@ else % Multi-Tract connectome
                             [ea_space, options.primarytemplate, '.nii'], ...
                             [options.subj.subjDir, filesep, 'forwardTransform'], ...
                             preopAnchor)';
+
+                        % Re-filter by length in native space (the warp may have
+                        % shortened fibers below the threshold)
+                        fiberFiltered(i) = ea_filterfiber_len(fiberFiltered{i}, settings.axonLength(t)+inlay);
                     end
-    
-                    fibers = zeros(size(fiberFiltered{i}.fibers,1),5);
-                    fibers(:,[1,2,3,5]) = fiberFiltered{i}.fibers;
-                    fibers(:,4) = repelem(1:length(fiberFiltered{i}.idx), fiberFiltered{i}.idx)';
-                    fiberFiltered{i}.fibers = fibers;
-    
-                    % store the original number of fibers
-                    % to compute percent activation
-                    fiberFiltered{i}.origNum = size(conn.idx,1);
-    
-                    fibersFound(t,i) = 1;
+
+                    % The native-space length filter above may have emptied this
+                    % element, so re-check before rearranging columns.
+                    if ~isempty(fiberFiltered{i}.fibers)
+                        fibers = zeros(size(fiberFiltered{i}.fibers,1),5);
+                        fibers(:,[1,2,3,5]) = fiberFiltered{i}.fibers;
+                        fibers(:,4) = repelem(1:length(fiberFiltered{i}.idx), fiberFiltered{i}.idx)';
+                        fiberFiltered{i}.fibers = fibers;
+
+                        % store the original number of fibers
+                        % to compute percent activation
+                        fiberFiltered{i}.origNum = size(conn.idx,1);
+
+                        fibersFound(t,i) = 1;
+                    end
                 end
-    
+
                 if i == 1
                     data1.(tractName) = fiberFiltered{1};
                 else

--- a/ext_libs/OSS-DBS/genvat_butenko/ea_prepare_fibers.m
+++ b/ext_libs/OSS-DBS/genvat_butenko/ea_prepare_fibers.m
@@ -108,6 +108,17 @@ if ~startsWith(settings.connectome, 'Multi-Tract: ') % Normal connectome
         inlay = 0.5;
         if ~options.native || patient_specific
             fiberFiltered = ea_filterfiber_len(fiberFiltered, settings.axonLength+inlay);
+        else
+            % Length filter is deferred to native space (after the warp).
+            % ea_filterfiber_len would also normalize empty hemispheres into a
+            % struct with empty .fibers/.idx; ea_filterfiber_stim leaves them
+            % as a bare []. Replicate that normalization so downstream code can
+            % dot-index every element safely.
+            for fi = 1:numel(fiberFiltered)
+                if ~isstruct(fiberFiltered{fi})
+                    fiberFiltered{fi} = struct('fibers', [], 'idx', []);
+                end
+            end
         end
 
         % Move original fiber id to the 5th column, the 4th column will be 1:N
@@ -274,6 +285,17 @@ else % Multi-Tract connectome
             inlay = 0.5;
             if ~options.native || patient_specific
                 fiberFiltered = ea_filterfiber_len(fiberFiltered, settings.axonLength(t)+inlay);
+            else
+                % Length filter is deferred to native space (after the warp).
+                % ea_filterfiber_len would also normalize empty hemispheres into
+                % a struct with empty .fibers/.idx; ea_filterfiber_stim leaves
+                % them as a bare []. Replicate that normalization so downstream
+                % code can dot-index every element safely.
+                for fi = 1:numel(fiberFiltered)
+                    if ~isstruct(fiberFiltered{fi})
+                        fiberFiltered{fi} = struct('fibers', [], 'idx', []);
+                    end
+                end
             end
 
             % Move original fiber id to the 5th column, the 4th column will be 1:N

--- a/ext_libs/OSS-DBS/genvat_butenko/ea_save_ossdbs_settings.m
+++ b/ext_libs/OSS-DBS/genvat_butenko/ea_save_ossdbs_settings.m
@@ -9,8 +9,15 @@ arguments
     outputPaths % various paths to conform with lead-dbs BIDS structure
 end
 
+% Skip destructive cleanup (and the parameter-file overwrite) when only
+% postprocessing existing cluster results — those folders contain the
+% Axon_state_*.mat / Pathway_status_*.json we need to keep.
+postprocess_cluster = isfield(settings,'postprocess_cluster') && settings.postprocess_cluster;
+
 parameterFile = fullfile(outputPaths.outputDir, 'oss-dbs_parameters.mat');
-save(parameterFile, 'settings', '-v7.3');
+if ~postprocess_cluster
+    save(parameterFile, 'settings', '-v7.3');
+end
 ea_savestimulation(S, options);
 if options.native
     poptions = options;
@@ -18,16 +25,18 @@ if options.native
     ea_savestimulation(S, poptions);
 end
 
-% Delete previous results from stimSetMode
-ea_delete([outputPaths.outputDir, filesep, 'Result_StimProt_*']);
-if options.native
-    ea_delete([outputPaths.templateOutputDir, filesep, 'Result_StimProt_*']);
-end
+if ~postprocess_cluster
+    % Delete previous results from stimSetMode
+    ea_delete([outputPaths.outputDir, filesep, 'Result_StimProt_*']);
+    if options.native
+        ea_delete([outputPaths.templateOutputDir, filesep, 'Result_StimProt_*']);
+    end
 
-% full clean-up for V2 (Lead-DBS outputs are still kept!)
-ea_delete([outputPaths.outputDir, filesep, 'OSS_sim_files*']);
-ea_delete([outputPaths.outputDir, filesep, 'skip_rh.txt']);
-ea_delete([outputPaths.outputDir, filesep, 'skip_lh.txt']);
+    % full clean-up for V2 (Lead-DBS outputs are still kept!)
+    ea_delete([outputPaths.outputDir, filesep, 'OSS_sim_files*']);
+    ea_delete([outputPaths.outputDir, filesep, 'skip_rh.txt']);
+    ea_delete([outputPaths.outputDir, filesep, 'skip_lh.txt']);
+end
 
 %% Run OSS-DBS
 setenv('LD_LIBRARY_PATH', ''); % Clear LD_LIBRARY_PATH to resolve conflicts


### PR DESCRIPTION
## Summary
Adds a `postprocess_cluster` mode to `ea_genvat_butenko`, allowing Lead-DBS to run
only the postprocessing step when OSS-DBS was already executed externally (e.g. on
an HPC cluster). Also includes two independent PAM fixes found along the way.

## Changes

### `postprocess_cluster` mode (new)
- New `postprocess_cluster` flag (default `0`) that skips the OSS-DBS simulation
  loop and goes straight to Lead-DBS postprocessing on existing results.
- Gates all destructive cleanup (`ea_prepare_fibers`, `ea_save_ossdbs_settings`)
  so cluster output is never wiped; forces `reuse_warped_connectome` to keep
  fiber-ID consistency with the existing `Axon_state_*.mat`.
- Fully backward compatible: with the flag off, every changed condition reduces to
  the original behavior.

### Fixes
- **Fiber length filter in native space:** the minimal-length filter was applied in
  MNI space before warping; the non-rigid warp can shorten fibers below threshold.
  It is now deferred to run after the warp in native space (MNI/patient-specific
  paths unchanged), with guards for emptied/empty hemispheres.
- **Stale prob-PAM files:** `ea_get_probab_axon_state` now ignores leftover
  unnumbered `Pathway_status_<pathway>.json` files from earlier deterministic/
  cancelled runs (which were mis-parsed and caused a `fileread` crash for prob-PAM), and skips
  rather than crashes on a missing per-sample file. No-op for clean runs.

## Testing
- Verified backward compatibility (flag off → original code paths).
- `postprocess_cluster` validated end-to-end on probabilistic-PAM cluster output
  (single- and multi-source patients).
- Stale-file safeguard reproduced and confirmed against the original crash.
