### PR TITLE
Fix ITK displacement field metadata for EasyReg and SynthMorph

### DIFF
--- a/ext_libs/EasyReg/ea_easyreg.m
+++ b/ext_libs/EasyReg/ea_easyreg.m
@@ -67,14 +67,14 @@ end
 
 function [] = freesurfer_nii_to_itk_h5(warp_file_in, warp_file_out)
 
-% substract mm coordinates for each voxel
-n = load_nii(warp_file_in);
+% Subtract millimeter coordinates for each voxel
+n = load_untouch_nii(warp_file_in);
 s = n.hdr.dime.dim(2:4);
 index = 1:prod(s);
 [v1,v2,v3] = ind2sub(s,index);
 mm = ea_vox2mm([v1',v2',v3'], ea_get_affine(warp_file_in)); % Need to do vox2mm since EasyReg uses disp_crs format)
 mm = reshape(mm, [s,3]);
-out = n.img - mm;
+out = apply_nifti_scaling(n) - mm;
 
 % reshape output
 out_rows = [-reshape(out(:,:,:,1),1,[]); -reshape(out(:,:,:,2),1,[]); reshape(out(:,:,:,3),1,[])];
@@ -83,23 +83,27 @@ out_column = reshape(out_rows,[],1);
 % copy template h5 file
 copyfile(fullfile(ea_getearoot, 'ext_libs', 'EasyReg', 'itk_h5_template.h5'), warp_file_out);
 
-if ~strcmp(ea_getspace, 'MNI152NLin2009bAsym')
-    % calculate TransformFixedParameters
-    spacedef = ea_getspacedef;
-    primarytemplate = [ea_space, spacedef.templates{1}, '.nii'];
-    hdr = ea_fslhd(primarytemplate);
-    TransformFixedParameters = zeros(18,1);
-    TransformFixedParameters(1:3) = [hdr.dim1; hdr.dim2; hdr.dim3];
-    TransformFixedParameters(4:6) = [-hdr.sto_xyz1(4); -hdr.sto_xyz2(4); hdr.sto_xyz3(4)]; % RAS to LPS applied
-    TransformFixedParameters(7:9) = [hdr.pixdim1; hdr.pixdim2; hdr.pixdim3];
-    TransformFixedParameters(10:18) = [-hdr.sto_xyz1(1:3)'/hdr.pixdim1; -hdr.sto_xyz2(1:3)'/hdr.pixdim2; hdr.sto_xyz3(1:3)'/hdr.pixdim3]; % RAS to LPS applied
-
-    % update TransformFixedParameters in h5
-    h5write(warp_file_out, "/TransformGroup/0/TransformFixedParameters", TransformFixedParameters);
-end
+% update TransformFixedParameters in h5
+h5write(warp_file_out, "/TransformGroup/0/TransformFixedParameters", ea_field_ref2itk(warp_file_in));
 
 % save TransformParameters in h5 
 h5create(warp_file_out, "/TransformGroup/0/TransformParameters", numel(out_column));
 h5write(warp_file_out, "/TransformGroup/0/TransformParameters", out_column);
+
+end
+
+
+function img = apply_nifti_scaling(nii)
+
+img = double(nii.img);
+slope = double(nii.hdr.dime.scl_slope);
+intercept = double(nii.hdr.dime.scl_inter);
+
+if isfinite(slope) && slope ~= 0
+    if ~isfinite(intercept)
+        intercept = 0;
+    end
+    img = img .* slope + intercept;
+end
 
 end

--- a/ext_libs/SynthMorph/ea_synthmorph.m
+++ b/ext_libs/SynthMorph/ea_synthmorph.m
@@ -64,7 +64,7 @@ end
 
 function [] = freesurfer_nii_to_itk_h5(warp_file_in, warp_file_out)
 
-% substract mm coordinates for each voxel
+% Subtract millimeter coordinates for each voxel
 n = load_nii(warp_file_in);
 out = n.img;
 
@@ -75,20 +75,8 @@ out_column = reshape(out_rows,[],1);
 % copy template h5 file
 copyfile(fullfile(ea_getearoot, 'ext_libs', 'EasyReg', 'itk_h5_template.h5'), warp_file_out);
 
-if ~strcmp(ea_getspace, 'MNI152NLin2009bAsym')
-    % calculate TransformFixedParameters
-    spacedef = ea_getspacedef;
-    primarytemplate = [ea_space, spacedef.templates{1}, '.nii'];
-    hdr = ea_fslhd(primarytemplate);
-    TransformFixedParameters = zeros(18,1);
-    TransformFixedParameters(1:3) = [hdr.dim1; hdr.dim2; hdr.dim3];
-    TransformFixedParameters(4:6) = [-hdr.sto_xyz1(4); -hdr.sto_xyz2(4); hdr.sto_xyz3(4)]; % RAS to LPS applied
-    TransformFixedParameters(7:9) = [hdr.pixdim1; hdr.pixdim2; hdr.pixdim3];
-    TransformFixedParameters(10:18) = [-hdr.sto_xyz1(1:3)'/hdr.pixdim1; -hdr.sto_xyz2(1:3)'/hdr.pixdim2; hdr.sto_xyz3(1:3)'/hdr.pixdim3]; % RAS to LPS applied
-
-    % update TransformFixedParameters in h5
-    h5write(warp_file_out, "/TransformGroup/0/TransformFixedParameters", TransformFixedParameters);
-end
+% update TransformFixedParameters in h5
+h5write(warp_file_out, "/TransformGroup/0/TransformFixedParameters", ea_field_ref2itk(warp_file_in));
 
 % save TransformParameters in h5 
 h5create(warp_file_out,"/TransformGroup/0/TransformParameters", numel(out_column));

--- a/helpers/ea_field_ref2itk.m
+++ b/helpers/ea_field_ref2itk.m
@@ -1,0 +1,25 @@
+function TransformFixedParameters = ea_field_ref2itk(reference_image)
+%EA_FIELD_REF2ITK Build ITK displacement-field fixed parameters from a NIfTI grid.
+
+hdr = ea_fslhd(reference_image);
+
+spacing = [hdr.pixdim1, hdr.pixdim2, hdr.pixdim3];
+if any(~isfinite(spacing)) || any(spacing <= 0)
+    error('Invalid voxel spacing in reference image: %s', reference_image);
+end
+
+stoX = hdr.sto_xyz1(1:3);
+stoY = hdr.sto_xyz2(1:3);
+stoZ = hdr.sto_xyz3(1:3);
+voxToRAS = [stoX(:)'; stoY(:)'; stoZ(:)'];
+
+rasToLPS = diag([-1, -1, 1]);
+direction = rasToLPS * voxToRAS * diag(1 ./ spacing);
+
+TransformFixedParameters = zeros(18, 1);
+TransformFixedParameters(1:3) = [hdr.dim1; hdr.dim2; hdr.dim3];
+TransformFixedParameters(4:6) = [-hdr.sto_xyz1(4); -hdr.sto_xyz2(4); hdr.sto_xyz3(4)];
+TransformFixedParameters(7:9) = spacing(:);
+TransformFixedParameters(10:18) = reshape(direction', [], 1);
+
+end


### PR DESCRIPTION
## Summary

Fix ITK displacement-field metadata written during EasyReg and SynthMorph FreeSurfer-to-ITK h5 conversion.

This adds a shared helper for deriving ITK fixed parameters from the actual NIfTI displacement-field grid, and uses it in both EasyReg and SynthMorph conversion paths. EasyReg also keeps the `load_untouch_nii` handling needed for affected oblique fields.

## Background

EasyReg and SynthMorph produce FreeSurfer-style displacement fields that Lead-DBS converts to ITK/Slicer-compatible `.h5` transforms. During this conversion, the h5 `TransformFixedParameters` must describe the physical grid on which the displacement vectors live: image size, origin, spacing, and direction matrix.

The previous implementation built these fixed parameters inline in both EasyReg and SynthMorph. The direction part was assembled from NIfTI affine rows and voxel sizes.

## Problem

The old direction-matrix construction is correct for simple cases such as isotropic grids or axis-aligned grids, but can be wrong when the displacement field reference grid is both anisotropic and oblique.

Lead-DBS usually reduces this risk by reslicing the pre-op anchor to an isotropic `0.7^3 mm` grid, but this is not guaranteed. Two relevant cases are:

- If preprocessing first runs with pre-op images only, `ea_autocoord` skips the anchor reslice step. If post-op CT is added later, the existing preprocessed anchor can remain on its native anisotropic oblique grid.
- `ea_resliceanat` only resamples when at least one voxel dimension is larger than 0.7 mm. High-resolution anisotropic anchors, for example `0.5 x 0.5 x 0.6 mm`, are therefore not resampled to `0.7^3 mm`.

For anisotropic oblique grids, normalizing affine rows by one spacing component per row does not produce the ITK direction matrix. The direction should be derived from voxel-axis columns, normalized by the corresponding spacing, and converted from RAS to LPS. If the wrong direction is written into the h5 transform, ITK/Slicer/ANTs can interpret the displacement field on the wrong physical grid, causing mm-scale mismatch between normalized anatomy, CT artifacts, and reconstructed electrode coordinates.

In EasyReg, affected fields may also fail earlier because `load_nii` rejects non-orthogonal or sheared NIfTI affines. These displacement-field files should be read without applying affine reorientation, while preserving standard NIfTI `scl_slope/scl_inter` scaling before displacement values are used.

## Changes

- Add `ea_field_ref2itk(reference_image)` to construct the 18-value ITK displacement-field fixed-parameter vector from a NIfTI grid:
  - image size
  - LPS origin
  - voxel spacing
  - row-major ITK/SimpleITK direction matrix
- Replace duplicated inline `TransformFixedParameters` construction in:
  - EasyReg
  - SynthMorph
- In EasyReg, use `load_untouch_nii` for FreeSurfer displacement fields and preserve standard NIfTI `scl_slope/scl_inter` scaling before computing `field - voxel_mm`.

## Validation

Local validation performed before opening this draft:

- MATLAB self-test with synthetic isotropic and oblique anisotropic NIfTI grids:
  - isotropic grids match the old behavior
  - anisotropic oblique grids differ from the old row/spacing bug
  - direction rows are unit-length and orthonormal
  - direction serialization follows ITK/SimpleITK row-major matrix convention
- EasyReg was tested on an anisotropic coregistered T1 in a temporary workspace and passed manual review.